### PR TITLE
Fix includes example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ If you want to add include directories for `node-sass` add them in the
 ```
 {
 	"node-sass": {
-		"in"scripts": {
-    "test": "grunt test"
-  },cludePaths": [
+		"includePaths": [
 			"./styles"
 		]
 	}


### PR DESCRIPTION
Hi, @rafinskipg.

The code sample that tells you how to add new directories to `includePaths` has been broken since 8382402967606617dbd86d9a05284c971b92cf68.

So, here is the patch. :)
