### PR TITLE
Updated node-sass dependency to be a version that works with Node 5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 	],
 	"main": "lib/",
 	"dependencies": {
-		"node-sass": "^2.1.1",
-		"clean-css": "^3.1.0"
+		"node-sass": "^3.4.2",
+		"clean-css": "^3.4.9"
 	},
 	"devDependencies": {
 		"coffee-script": "^1.7.1",


### PR DESCRIPTION
I updated node-sass to ~3.4.2 since the 2.1.1 version appears to have difficulties in Node 4 and does not work (bindings fail to create) in Node 5. I made a minor update to the clean-css version which wasn't entirely necessary. Tests pass.
